### PR TITLE
Fix the bugs that texture imageExtent.z init to 0

### DIFF
--- a/src/framework/Common/TextureHelper.cpp
+++ b/src/framework/Common/TextureHelper.cpp
@@ -49,7 +49,7 @@ namespace TextureHelper {
             imageCopy.imageSubresource.baseArrayLayer = 0;
             imageCopy.imageSubresource.layerCount     = 1;
             imageCopy.imageOffset                     = {0, 0, 0};
-            imageCopy.imageExtent                     = {128, 128};
+            imageCopy.imageExtent                     = {128, 128, 1};
 
             VkImageSubresourceRange subresourceRange{};
             subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;

--- a/src/framework/Core/SwapChain.cpp
+++ b/src/framework/Core/SwapChain.cpp
@@ -95,12 +95,6 @@ SwapChain::SwapChainSupportDetails SwapChain::querySwapChainSupport()
 
     uint32_t formatCount;
 
-
-
-
-
-
-
     vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, _surface, &formatCount, nullptr);
     if (formatCount != 0)
     {

--- a/src/framework/Core/SwapChain.h
+++ b/src/framework/Core/SwapChain.h
@@ -2,8 +2,6 @@
 
 #include "Core/Vulkan.h"
 
-#include <algorithm>
-
 class Device;
 
 class Surface;

--- a/src/framework/Core/Texture.cpp
+++ b/src/framework/Core/Texture.cpp
@@ -63,7 +63,11 @@ const Sampler& Texture::getSampler() const {
 //     texture->sampler = std::make_unique<Sampler>(device, VK_SAMPLER_ADDRESS_MODE_REPEAT, VK_FILTER_LINEAR, mipmaps.size());
 // }
 
-static void initVKTexture(Device& device, std::unique_ptr<Texture>& texture, CommandBuffer& commandBuffer, Buffer& imageBuffer, uint32_t offset) {
+static void initVKTexture(Device& device, 
+                        std::unique_ptr<Texture>& texture,
+                        CommandBuffer& commandBuffer,
+                        Buffer& imageBuffer,
+                        uint32_t offset) {
     // texture->image->generateMipMapOnCpu();
     texture->image->createVkImage(device);
 


### PR DESCRIPTION
Update:
1. `TextureHelpler.cpp`  https://github.com/xiaoyaoing/Y-VK/blob/9c2c023efac14e0df654de115893cb293b48f223/src/framework/Common/TextureHelper.cpp#L52 which the imageExtent.z can‘t be 0. So update to
```
imageCopy.imageExtent = {128, 128, 1};
```