### PR TITLE
Create Transient Buffer class

### DIFF
--- a/src/RayTracer/Utils/RTSceneUtil.cpp
+++ b/src/RayTracer/Utils/RTSceneUtil.cpp
@@ -64,7 +64,7 @@ RTLight RTSceneEntryImpl::toRTLight(Scene& scene, const SgLight& light) {
         rtLight.light_type                       = RT_LIGHT_TYPE_INFINITE;
         Texture* tex                             = scene.getTextures().operator[](rtLight.light_texture_id).get();
         auto                               aceel = hdrSampling.createEnvironmentAccel(reinterpret_cast<const float*>(tex->image->getData().data()), tex->image->getExtent2D());
-        infiniteSamplingBuffer                   = std::make_unique<Buffer>(device, sizeof(EnvAccel) * aceel.size(), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU, aceel.data());
+        infiniteSamplingBuffer                   = std::make_unique<Buffer>(device, sizeof(EnvAccel) * aceel.size(), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU, aceel.data());
         sceneDesc.env_sampling_addr              = infiniteSamplingBuffer->getDeviceAddress();
         sceneDesc.envmap_idx                     = lights.size();
     }

--- a/src/framework/Core/Buffer.h
+++ b/src/framework/Core/Buffer.h
@@ -6,7 +6,6 @@ class CommandBuffer;
 class Device;
 
 class Buffer {
-  
 public:
     ~Buffer();
 

--- a/src/framework/Core/TransientBuffer.cpp
+++ b/src/framework/Core/TransientBuffer.cpp
@@ -1,0 +1,89 @@
+#include "TransientBuffer.h"
+#include "Core/RenderContext.h"
+
+TransientBuffer::TransientBuffer(Device& device, 
+                                VkBufferUsageFlags usageFlags,
+                                VkDeviceSize size,
+                                VkDeviceSize sizeInByte)
+    : _device(device) {
+    _buffer = std::make_unique<Buffer>(device, 
+                                    size,
+                                    usageFlags, 
+                                    VMA_MEMORY_USAGE_CPU_TO_GPU);
+    _freeList.push_back(SubAlloc(0, sizeInByte));
+}
+
+TransientBuffer::~TransientBuffer() {}
+
+SubAlloc TransientBuffer::allocate(VkDeviceSize size, CommandBuffer& commandBuffer) {
+    SubAlloc ret;
+
+    // Find a free sub alloc
+    bool found = false;
+    auto iter = _freeList.begin();
+    auto fit_iter = iter;
+
+    for(; iter != _freeList.end(); ++iter) {
+        if (iter->length >= size) {
+            fit_iter = iter;
+            found = true;
+            break;
+        }
+    }
+
+    // reallocate a larger buffer
+    if (!found) {
+        const auto old_buffer_size = _buffer->getSize();
+        const auto buffer_size = std::max(old_buffer_size * 2, old_buffer_size);
+        SubAlloc alloc(old_buffer_size, buffer_size - old_buffer_size);
+        // Merge the new buffer with the previous one if they are contiguous
+        if(!_freeList.empty() && _freeList.back().offset + _freeList.back().length == alloc.offset) {
+            _freeList.back().length += alloc.length;
+        } else {
+            _freeList.push_back(alloc);
+        }
+        fit_iter = _freeList.end();
+        fit_iter--;
+        // Copy the old buffer data to the new larger buffer
+
+        std::unique_ptr<Buffer> larger_buffer = Buffer::FromBuffer(_device, 
+                                                                    commandBuffer, 
+                                                                    *_buffer, 
+                                                                    _buffer->getUsageFlags(), 
+                                                                    0, 
+                                                                    buffer_size);
+        _buffer = std::move(larger_buffer);
+    }
+
+    VkDeviceSize left_size = fit_iter->length - size;
+    ret.offset = fit_iter->offset;
+    ret.length = size;
+    if (left_size == 0) {
+        _freeList.erase(fit_iter);
+    } else {
+        fit_iter->offset += size;
+        fit_iter->length = left_size;
+    }
+
+    return ret;
+}
+
+void TransientBuffer::deallocate(SubAlloc const & alloc) {
+    if(alloc.length == 0) {
+        return;
+    }
+    _freeList.push_back(alloc);
+    _freeList.sort([](const SubAlloc &a, const SubAlloc &b) { return a.offset < b.offset; });
+
+    for (auto it = _freeList.begin(); it != _freeList.end(); ++it) {
+        auto next = std::next(it);
+        if (next != _freeList.end() && it->offset + it->length == next->offset) {
+            it->length += next->length;
+            _freeList.erase(next);
+            --it; // Recheck the current iterator after merging
+        }
+    }
+}
+
+
+

--- a/src/framework/Core/TransientBuffer.h
+++ b/src/framework/Core/TransientBuffer.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Buffer.h"
+#include "Device.h"
+
+struct SubAlloc{
+    VkDeviceSize offset;
+    VkDeviceSize length;
+
+    SubAlloc() : offset(0), length(0) {}
+    SubAlloc(VkDeviceSize offset, VkDeviceSize length) : offset(offset), length(length) {}
+};
+
+class TransientBuffer {
+public:
+    TransientBuffer(Device &device, 
+                    VkBufferUsageFlags usageFlags,
+                    VkDeviceSize initialSize,
+                    VkDeviceSize sizeInByte);
+    ~TransientBuffer();
+    
+    SubAlloc allocate(VkDeviceSize size, CommandBuffer& commandBuffer);
+    // deallocate the sub alloc
+    void deallocate(SubAlloc const & subAlloc);
+
+    inline VkBuffer getBuffer() const { return _buffer->getHandle(); }
+    inline VkDeviceAddress getDeviceAddress() const { return _buffer->getDeviceAddress(); }
+
+private:
+    Device& _device;
+    std::unique_ptr<Buffer> _buffer;
+    std::list<SubAlloc> _freeList;
+};


### PR DESCRIPTION
# Pull Request Title: Integrate TransientBuffer for Efficient Memory Management

## Description

This PR introduces the `TransientBuffer` class to the codebase, which provides efficient memory management for vertex and index data. The `TransientBuffer` class dynamically allocates and deallocates memory, ensuring optimal usage of GPU resources. Additionally, an adapter pattern is used to integrate `TransientBuffer` with the existing framework, minimizing the need for extensive changes to existing interfaces.

## Changes

- **Added `TransientBuffer` class**:
  - Implements dynamic memory allocation and deallocation.
  - Merges adjacent free blocks in the `deallocate` method.
  - Finds suitable free blocks for allocation in the `allocate` method.
  
- **Created `TransientBufferAdapter` class**:
  - Adapts `TransientBuffer` to the existing `Buffer` interface.
  - Allows seamless integration with `scene.sceneIndexBuffer` and `scene.sceneVertexBuffer`.

- **Updated `RuntimeSceneManager`**:
  - Utilizes `TransientBufferAdapter` for managing vertex and index buffers.
  - Ensures efficient memory management during the addition of primitives.

## Motivation and Context

The primary motivation for this PR is to enhance the memory management capabilities of the framework. By introducing `TransientBuffer`, we aim to:
- Reduce memory fragmentation.
- Improve the performance of memory allocation and deallocation.
- Ensure that the framework can handle dynamic changes in vertex and index data efficiently.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


